### PR TITLE
Treasury cancel

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -50,7 +50,7 @@ pub fn instantiate(
         fee_collector: deps.api.addr_validate(&msg.fee_collector)?,
         protocol_admin: deps.api.addr_validate(&msg.protocol_admin)?,
         accepted_in_denom: msg.accepted_in_denom,
-        toc_version: msg.toc_version.clone(),
+        tos_version: msg.tos_version.clone(),
     };
     CONFIG.save(deps.storage, &config)?;
 
@@ -66,7 +66,7 @@ pub fn instantiate(
         attr("exit_fee_percent", msg.exit_fee_percent.to_string()),
         attr("fee_collector", msg.fee_collector),
         attr("protocol_admin", msg.protocol_admin),
-        attr("toc_version", msg.toc_version),
+        attr("tos_version", msg.tos_version),
     ];
     Ok(Response::default().add_attributes(attrs))
 }
@@ -89,7 +89,7 @@ pub fn execute(
             start_time,
             end_time,
             threshold,
-            toc_version,
+            tos_version,
         } => execute_create_stream(
             deps,
             env,
@@ -103,7 +103,7 @@ pub fn execute(
             start_time,
             end_time,
             threshold,
-            toc_version,
+            tos_version,
         ),
         ExecuteMsg::UpdateOperator {
             stream_id,
@@ -121,10 +121,10 @@ pub fn execute(
             stream_id,
             operator_target,
             operator,
-            toc_version,
+            tos_version,
         } => {
-            if toc_version != CONFIG.load(deps.storage)?.toc_version {
-                return Err(ContractError::InvalidTocVersion {});
+            if tos_version != CONFIG.load(deps.storage)?.tos_version {
+                return Err(ContractError::InvalidToSVersion {});
             }
 
             let stream = STREAMS.load(deps.storage, stream_id)?;
@@ -216,7 +216,7 @@ pub fn execute(
             fee_collector,
             accepted_in_denom,
             exit_fee_percent,
-            toc_version,
+            tos_version,
         } => execute_update_config(
             deps,
             env,
@@ -228,7 +228,7 @@ pub fn execute(
             fee_collector,
             accepted_in_denom,
             exit_fee_percent,
-            toc_version,
+            tos_version,
         ),
     }
 }
@@ -246,7 +246,7 @@ pub fn execute_create_stream(
     start_time: Timestamp,
     end_time: Timestamp,
     threshold: Option<Uint256>,
-    toc_version: String,
+    tos_version: String,
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     if end_time < start_time {
@@ -275,8 +275,8 @@ pub fn execute_create_stream(
         return Err(ContractError::ZeroOutSupply {});
     }
 
-    if toc_version != config.toc_version {
-        return Err(ContractError::InvalidTocVersion {});
+    if tos_version != config.tos_version {
+        return Err(ContractError::InvalidToSVersion {});
     }
 
     if out_denom == config.stream_creation_denom {
@@ -1066,7 +1066,7 @@ pub fn execute_update_config(
     fee_collector: Option<String>,
     accepted_in_denom: Option<String>,
     exit_fee_percent: Option<Decimal256>,
-    toc_version: Option<String>,
+    tos_version: Option<String>,
 ) -> Result<Response, ContractError> {
     let mut cfg = CONFIG.load(deps.storage)?;
 
@@ -1086,9 +1086,9 @@ pub fn execute_update_config(
         }
     }
 
-    if let Some(toc_version) = toc_version.clone() {
-        if toc_version != cfg.toc_version {
-            return Err(ContractError::InvalidTocVersion {});
+    if let Some(tos_version) = tos_version.clone() {
+        if tos_version != cfg.tos_version {
+            return Err(ContractError::InvalidToSVersion {});
         }
     }
 
@@ -1101,7 +1101,7 @@ pub fn execute_update_config(
     let collector = maybe_addr(deps.api, fee_collector)?.unwrap_or(cfg.fee_collector);
     cfg.fee_collector = collector;
     cfg.exit_fee_percent = exit_fee_percent.unwrap_or(cfg.exit_fee_percent);
-    cfg.toc_version = toc_version.unwrap_or(cfg.toc_version);
+    cfg.tos_version = tos_version.unwrap_or(cfg.tos_version);
 
     CONFIG.save(deps.storage, &cfg)?;
 
@@ -1115,7 +1115,7 @@ pub fn execute_update_config(
         attr("stream_creation_denom", cfg.stream_creation_denom),
         attr("stream_creation_fee", cfg.stream_creation_fee),
         attr("fee_collector", cfg.fee_collector),
-        attr("toc_version", cfg.toc_version),
+        attr("tos_version", cfg.tos_version),
     ];
 
     Ok(Response::default().add_attributes(attributes))

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,6 +155,6 @@ pub enum ContractError {
     #[error("Invalid exit fee")]
     InvalidStreamExitFee {},
 
-    #[error("Invalid terms of condition")]
-    InvalidTocVersion {},
+    #[error("Invalid terms and services")]
+    InvalidToSVersion {},
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,4 +154,7 @@ pub enum ContractError {
 
     #[error("Invalid exit fee")]
     InvalidStreamExitFee {},
+
+    #[error("Invalid terms of condition")]
+    InvalidTocVersion {},
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,4 +157,13 @@ pub enum ContractError {
 
     #[error("Invalid terms and services")]
     InvalidToSVersion {},
+
+    #[error("Treasury cancel period : Active")]
+    TreasuryCancelPeriodActive {},
+
+    #[error("Treasury cancel period : Ended")]
+    TreasuryCancelPeriodEnded {},
+
+    #[error("Treasury cancel period : Not set")]
+    TreasuryCancelPeriodNotSet {},
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -21,7 +21,7 @@ pub struct InstantiateMsg {
     /// Accepted in_denom to buy out_tokens
     pub accepted_in_denom: String,
     /// Version or hash of terms and condition document
-    pub toc_version: String,
+    pub tos_version: String,
 }
 
 #[cw_serde]
@@ -50,7 +50,7 @@ pub enum ExecuteMsg {
         /// Minimum amount of `spent_in` for a stream to be finalized.
         threshold: Option<Uint256>,
         /// Version or hash of terms and condition document
-        toc_version: String,
+        tos_version: String,
     },
     /// Update stream and calculates distribution state.
     UpdateStream {
@@ -76,7 +76,7 @@ pub enum ExecuteMsg {
         /// operator can subscribe/withdraw/update position.
         operator: Option<String>,
         /// Version or hash of terms and condition document
-        toc_version: String,
+        tos_version: String,
     },
     /// Withdraw unspent tokens in balance.
     Withdraw {
@@ -139,7 +139,7 @@ pub enum ExecuteMsg {
         fee_collector: Option<String>,
         accepted_in_denom: Option<String>,
         exit_fee_percent: Option<Decimal256>,
-        toc_version: Option<String>,
+        tos_version: Option<String>,
     },
     ResumeStream {
         stream_id: u64,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -147,6 +147,9 @@ pub enum ExecuteMsg {
     CancelStream {
         stream_id: u64,
     },
+    TreasuryCancelStream {
+        stream_id: u64,
+    },
 }
 
 #[cw_serde]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -20,6 +20,8 @@ pub struct InstantiateMsg {
     pub protocol_admin: String,
     /// Accepted in_denom to buy out_tokens
     pub accepted_in_denom: String,
+    /// Version or hash of terms and condition document
+    pub toc_version: String,
 }
 
 #[cw_serde]
@@ -47,6 +49,8 @@ pub enum ExecuteMsg {
         end_time: Timestamp,
         /// Minimum amount of `spent_in` for a stream to be finalized.
         threshold: Option<Uint256>,
+        /// Version or hash of terms and condition document
+        toc_version: String,
     },
     /// Update stream and calculates distribution state.
     UpdateStream {
@@ -71,6 +75,8 @@ pub enum ExecuteMsg {
         operator_target: Option<String>,
         /// operator can subscribe/withdraw/update position.
         operator: Option<String>,
+        /// Version or hash of terms and condition document
+        toc_version: String,
     },
     /// Withdraw unspent tokens in balance.
     Withdraw {
@@ -133,6 +139,7 @@ pub enum ExecuteMsg {
         fee_collector: Option<String>,
         accepted_in_denom: Option<String>,
         exit_fee_percent: Option<Decimal256>,
+        toc_version: Option<String>,
     },
     ResumeStream {
         stream_id: u64,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 use crate::ContractError;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Binary, Decimal256, Storage, Timestamp, Uint128, Uint256, Uint64};
+use cosmwasm_std::{Addr, Decimal256, Storage, Timestamp, Uint128, Uint256, Uint64};
 use cw_storage_plus::{Item, Map};
 use std::ops::Mul;
 
@@ -206,25 +206,24 @@ pub const POSITIONS: Map<(StreamId, &Addr), Position> = Map::new("positions");
 /// Both for creator and subscriber
 pub const TOS_SIGNED: Map<(StreamId, &Addr), String> = Map::new("tos_signed");
 
-pub struct TreasuryStreamCancelPeriod {
-    pub treasury: Addr,
+#[cw_serde]
+pub struct TreasuryCancelStreamPeriod {
     pub cancel_period_start: Timestamp,
     pub cancel_period_end: Timestamp,
 }
 
-pub const TREASURY_STREAM_CANCEL_PERIOD: Map<StreamId, TreasuryStreamCancelPeriod> =
+pub const TREASURY_STREAM_CANCEL_PERIOD: Map<StreamId, TreasuryCancelStreamPeriod> =
     Map::new("treasury_stream_cancel_period");
-
-impl TreasuryStreamCancelPeriod {
-    pub fn new(treasury: Addr, min_seconds_until_start_time: u64, now: Timestamp) -> Self {
-        TreasuryStreamCancelPeriod {
-            treasury,
+// Implement default
+impl TreasuryCancelStreamPeriod {
+    pub fn new(min_seconds_until_start_time: u64, now: Timestamp) -> Self {
+        TreasuryCancelStreamPeriod {
             cancel_period_start: now,
             cancel_period_end: now.plus_seconds(min_seconds_until_start_time),
         }
     }
     // Check if now is in the cancel period
-    pub fn is_in_cancel_period(&self, now: Timestamp) -> bool {
+    pub fn is_active(&self, now: Timestamp) -> bool {
         now >= self.cancel_period_start && now <= self.cancel_period_end
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -205,6 +205,30 @@ pub const POSITIONS: Map<(StreamId, &Addr), Position> = Map::new("positions");
 /// Terms and services ipfs link signature signed by user
 /// Both for creator and subscriber
 pub const TOS_SIGNED: Map<(StreamId, &Addr), String> = Map::new("tos_signed");
+
+pub struct TreasuryStreamCancelPeriod {
+    pub treasury: Addr,
+    pub cancel_period_start: Timestamp,
+    pub cancel_period_end: Timestamp,
+}
+
+pub const TREASURY_STREAM_CANCEL_PERIOD: Map<StreamId, TreasuryStreamCancelPeriod> =
+    Map::new("treasury_stream_cancel_period");
+
+impl TreasuryStreamCancelPeriod {
+    pub fn new(treasury: Addr, min_seconds_until_start_time: u64, now: Timestamp) -> Self {
+        TreasuryStreamCancelPeriod {
+            treasury,
+            cancel_period_start: now,
+            cancel_period_end: now.plus_seconds(min_seconds_until_start_time),
+        }
+    }
+    // Check if now is in the cancel period
+    pub fn is_in_cancel_period(&self, now: Timestamp) -> bool {
+        now >= self.cancel_period_start && now <= self.cancel_period_end
+    }
+}
+
 // Testing module
 #[cfg(test)]
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 use crate::ContractError;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Binary, Decimal256, Storage, Timestamp, Uint128, Uint256, Uint64};
+use cosmwasm_std::{Addr, Decimal256, Storage, Timestamp, Uint128, Uint256, Uint64};
 use cw_storage_plus::{Item, Map};
 use std::ops::Mul;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -202,9 +202,9 @@ impl Position {
 // Position (stream_id, owner_addr) -> Position
 pub const POSITIONS: Map<(StreamId, &Addr), Position> = Map::new("positions");
 
-/// Terms and conditions ipfs link signature signed by user
+/// Terms and services ipfs link signature signed by user
 /// Both for creator and subscriber
-pub const TERMS_SIGNED: Map<(StreamId, &Addr), Binary> = Map::new("terms_signed");
+pub const TOS_SIGNED: Map<(StreamId, &Addr), String> = Map::new("tos_signed");
 // Testing module
 #[cfg(test)]
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 use crate::ContractError;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Decimal256, Storage, Timestamp, Uint128, Uint256, Uint64};
+use cosmwasm_std::{Addr, Binary, Decimal256, Storage, Timestamp, Uint128, Uint256, Uint64};
 use cw_storage_plus::{Item, Map};
 use std::ops::Mul;
 
@@ -22,6 +22,8 @@ pub struct Config {
     pub fee_collector: Addr,
     /// protocol admin can pause streams in case of emergency.
     pub protocol_admin: Addr,
+    /// Version or hash of terms and condition document
+    pub toc_version: String,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
@@ -200,6 +202,9 @@ impl Position {
 // Position (stream_id, owner_addr) -> Position
 pub const POSITIONS: Map<(StreamId, &Addr), Position> = Map::new("positions");
 
+/// Terms and conditions ipfs link signature signed by user
+/// Both for creator and subscriber
+pub const TERMS_SIGNED: Map<(StreamId, &Addr), Binary> = Map::new("terms_signed");
 // Testing module
 #[cfg(test)]
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,7 +23,7 @@ pub struct Config {
     /// protocol admin can pause streams in case of emergency.
     pub protocol_admin: Addr,
     /// Version or hash of terms and condition document
-    pub toc_version: String,
+    pub tos_version: String,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -667,7 +667,6 @@ mod test_module {
             end_time,
             None,   
 "v1".to_string(),
-            None
         )
             .unwrap_err();
         assert_eq!(res, ContractError::StreamUrlTooLong {});

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -73,6 +73,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         let res =
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap_err();
@@ -88,6 +89,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         let res =
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap_err();
@@ -102,10 +104,10 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
-        // invalid in_denom
         let treasury = "treasury";
         let name = "name";
         let url = "https://sample.url";
@@ -131,6 +133,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::InDenomIsNotAccepted {}));
         // end < start case
@@ -158,6 +161,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::StreamInvalidEndTime {}));
 
@@ -180,6 +184,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::StreamDurationTooShort {}));
 
@@ -202,6 +207,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::StreamInvalidStartTime {}));
 
@@ -224,6 +230,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::StreamStartsTooSoon {}));
 
@@ -246,6 +253,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::SameDenomOnEachSide {}));
 
@@ -268,6 +276,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::ZeroOutSupply {}));
 
@@ -302,6 +311,7 @@ mod test_module {
             start_time,
             end_time,
             Some(Uint256::zero()),
+            "v1".to_string(),
         )
         .unwrap_err();
         assert_eq!(
@@ -328,6 +338,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::NoFundsSent {}));
 
@@ -348,6 +359,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::StreamOutSupplyFundsRequired {}));
 
@@ -374,6 +386,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::StreamCreationFeeRequired {}));
 
@@ -400,6 +413,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::NoFundsSent {}));
 
@@ -426,6 +440,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::NoFundsSent {}));
 
@@ -446,6 +461,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         );
         assert_eq!(res, Err(ContractError::StreamOutSupplyFundsRequired {}));
 
@@ -476,6 +492,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -509,6 +526,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap_err();
         assert_eq!(err, ContractError::InvalidFunds {});
@@ -537,6 +555,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap_err();
         assert_eq!(err, ContractError::InvalidFunds {});
@@ -564,6 +583,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap_err();
         assert_eq!(res, ContractError::StreamNameTooShort {});
@@ -581,6 +601,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap_err();
         assert_eq!(res, ContractError::StreamNameTooLong {});
@@ -598,6 +619,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap_err();
         assert_eq!(res, ContractError::InvalidStreamName {});
@@ -625,6 +647,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap_err();
         assert_eq!(res, ContractError::StreamUrlTooShort {});
@@ -641,15 +664,15 @@ mod test_module {
             out_supply,
             start_time,
             end_time,
-            None,
+            None,   "v1".to_string(),
         )
             .unwrap_err();
         assert_eq!(res, ContractError::StreamUrlTooLong {});
 
         let res = execute_create_stream(
             deps.as_mut(),
-            env,
-            info,
+            env.clone(),
+            info.clone(),
             treasury.to_string(),
             "name".to_string(),
             Some("https://abc defghijklmnopqrstuvw.xyz/".to_string()),
@@ -659,10 +682,29 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap_err();
 
         assert_eq!(res, ContractError::InvalidStreamUrl {});
+
+        let res = execute_create_stream(
+            deps.as_mut(),
+            env,
+            info,
+            treasury.to_string(),
+            "name".to_string(),
+            Some("https://abcdefghijklmnopqrstuvw.xyz/".to_string()),
+            in_denom.to_string(),
+            out_denom.to_string(),
+            out_supply,
+            start_time,
+            end_time,
+            None,
+            "random".to_string(),
+        )
+        .unwrap_err();
+        assert_eq!(res, ContractError::InvalidTocVersion {});
 
         // happy path
         let mut env = mock_env();
@@ -687,6 +729,7 @@ mod test_module {
             start_time,
             end_time,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -717,6 +760,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -743,6 +787,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -754,6 +799,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::StreamEnded {});
@@ -766,6 +812,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, PaymentError::NoFunds {}.into());
@@ -778,12 +825,26 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
         assert_eq!(res, PaymentError::MissingDenom("in".to_string()).into());
 
         let stream = query_stream(deps.as_ref(), env, 1).unwrap();
         assert_eq!(stream.status, Status::Waiting);
+
+        // incorrect toc
+        let mut env = mock_env();
+        env.block.time = start.plus_seconds(100);
+        let info = mock_info("creator1", &[Coin::new(1_000_000, "in")]);
+        let msg = crate::msg::ExecuteMsg::Subscribe {
+            stream_id: 1,
+            operator_target: None,
+            operator: None,
+            toc_version: "random".to_string(),
+        };
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
+        assert_eq!(res, ContractError::InvalidTocVersion {});
 
         // first subscribe
         let mut env = mock_env();
@@ -793,6 +854,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -815,6 +877,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -827,6 +890,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env.clone(), info, msg);
         // dist index updated
@@ -860,6 +924,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -886,6 +951,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -898,6 +964,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(res.attributes[0].key, "action");
@@ -918,6 +985,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(res.attributes[0].key, "action");
@@ -950,6 +1018,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(res.attributes[0].key, "action");
@@ -1037,6 +1106,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1063,6 +1133,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -1074,6 +1145,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -1188,6 +1260,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1213,6 +1286,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -1224,6 +1298,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -1236,6 +1311,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: Some("random".to_string()),
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -1248,6 +1324,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -1322,6 +1399,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(
@@ -1430,6 +1508,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1456,6 +1535,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -1480,6 +1560,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -1521,6 +1602,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1547,6 +1629,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -1558,6 +1641,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -1630,6 +1714,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1656,6 +1741,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -1667,6 +1753,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -1678,6 +1765,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -1793,6 +1881,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1819,6 +1908,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -1831,6 +1921,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -1936,6 +2027,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1962,6 +2054,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -1974,6 +2067,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2061,6 +2155,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: in_denom.to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
         // Create stream
@@ -2086,6 +2181,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
         // First subscription
@@ -2097,6 +2193,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
         // Update
@@ -2162,6 +2259,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2188,6 +2286,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -2200,6 +2299,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2266,6 +2366,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2292,6 +2393,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -2304,6 +2406,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2316,6 +2419,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2378,6 +2482,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2404,6 +2509,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -2416,6 +2522,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2444,6 +2551,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
+            toc_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2520,6 +2628,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2553,6 +2662,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
+            toc_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2579,6 +2689,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(2)),
+            toc_version: None,
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -2595,6 +2706,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(2)),
+            toc_version: None,
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::InvalidStreamCreationFee {});
@@ -2611,6 +2723,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(101)),
+            toc_version: None,
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::InvalidExitFeePercent {});
@@ -2627,6 +2740,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(2)),
+            toc_version: None,
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2673,6 +2787,7 @@ mod test_module {
             start,
             end,
             None,
+            "v1".to_string(),
         )
         .unwrap();
 
@@ -2688,6 +2803,7 @@ mod test_module {
             fee_collector: Some("collector3".to_string()),
             accepted_in_denom: Some("new_denom2".to_string()),
             exit_fee_percent: Some(Decimal256::percent(5)),
+            toc_version: None,
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
         //query config
@@ -2745,6 +2861,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2771,6 +2888,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -2791,6 +2909,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2830,6 +2949,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
             assert_eq!(res, ContractError::StreamKillswitchActive {});
@@ -2843,6 +2963,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
             assert_eq!(res, ContractError::StreamKillswitchActive {});
@@ -2908,6 +3029,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2934,6 +3056,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -2946,6 +3069,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2971,6 +3095,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
             assert_eq!(res, ContractError::StreamKillswitchActive {});
@@ -2997,6 +3122,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap();
             assert_eq!(res.attributes[0].key, "action");
@@ -3051,6 +3177,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3077,6 +3204,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3089,6 +3217,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3177,6 +3306,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3203,6 +3333,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3215,6 +3346,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3369,6 +3501,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3395,6 +3528,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3407,6 +3541,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3456,6 +3591,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3482,6 +3618,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3534,6 +3671,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3561,6 +3699,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
             //second stream
@@ -3577,6 +3716,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3591,6 +3731,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3602,6 +3743,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3630,6 +3772,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3656,6 +3799,7 @@ mod test_module {
                 start,
                 end,
                 None,
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3668,6 +3812,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3783,6 +3928,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: in_denom.to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3809,6 +3955,7 @@ mod test_module {
                 start,
                 end,
                 Some(Uint256::from(250u128)),
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3821,6 +3968,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3894,6 +4042,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: in_denom.to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3920,6 +4069,7 @@ mod test_module {
                 start,
                 end,
                 Some(500u128.into()),
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -3932,6 +4082,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
@@ -3942,6 +4093,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
@@ -4039,6 +4191,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: in_denom.to_string(),
+                toc_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -4065,6 +4218,7 @@ mod test_module {
                 start,
                 end,
                 Some(1_000u128.into()),
+                "v1".to_string(),
             )
             .unwrap();
 
@@ -4077,6 +4231,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
@@ -4087,6 +4242,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
+                toc_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
             // Can not cancel stream before it ends

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -73,7 +73,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res =
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap_err();
@@ -89,7 +89,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res =
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap_err();
@@ -104,7 +104,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -704,7 +704,7 @@ mod test_module {
             "random".to_string(),
         )
         .unwrap_err();
-        assert_eq!(res, ContractError::InvalidTocVersion {});
+        assert_eq!(res, ContractError::InvalidToSVersion {});
 
         // happy path
         let mut env = mock_env();
@@ -760,7 +760,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -799,7 +799,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::StreamEnded {});
@@ -812,7 +812,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, PaymentError::NoFunds {}.into());
@@ -825,7 +825,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
         assert_eq!(res, PaymentError::MissingDenom("in".to_string()).into());
@@ -841,10 +841,10 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "random".to_string(),
+            tos_version: "random".to_string(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
-        assert_eq!(res, ContractError::InvalidTocVersion {});
+        assert_eq!(res, ContractError::InvalidToSVersion {});
 
         // first subscribe
         let mut env = mock_env();
@@ -854,7 +854,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -877,7 +877,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -890,7 +890,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env.clone(), info, msg);
         // dist index updated
@@ -924,7 +924,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -964,7 +964,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(res.attributes[0].key, "action");
@@ -985,7 +985,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(res.attributes[0].key, "action");
@@ -1018,7 +1018,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(res.attributes[0].key, "action");
@@ -1106,7 +1106,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1145,7 +1145,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -1260,7 +1260,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1298,7 +1298,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -1311,7 +1311,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: Some("random".to_string()),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -1324,7 +1324,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -1399,7 +1399,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(
@@ -1508,7 +1508,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1560,7 +1560,7 @@ mod test_module {
             stream_id: 1,
             operator_target: Some("creator1".to_string()),
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -1602,7 +1602,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1641,7 +1641,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg);
 
@@ -1714,7 +1714,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1753,7 +1753,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -1765,7 +1765,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -1881,7 +1881,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -1921,7 +1921,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2027,7 +2027,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2067,7 +2067,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2155,7 +2155,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: in_denom.to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
         // Create stream
@@ -2193,7 +2193,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
         // Update
@@ -2259,7 +2259,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2299,7 +2299,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2366,7 +2366,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2406,7 +2406,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2419,7 +2419,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2482,7 +2482,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2522,7 +2522,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2551,7 +2551,7 @@ mod test_module {
             stream_id: 1,
             operator_target: None,
             operator: None,
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2628,7 +2628,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2662,7 +2662,7 @@ mod test_module {
             fee_collector: "collector".to_string(),
             protocol_admin: "protocol_admin".to_string(),
             accepted_in_denom: "in".to_string(),
-            toc_version: "v1".to_string(),
+            tos_version: "v1".to_string(),
         };
         instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2689,7 +2689,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(2)),
-            toc_version: None,
+            tos_version: None,
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::Unauthorized {});
@@ -2706,7 +2706,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(2)),
-            toc_version: None,
+            tos_version: None,
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::InvalidStreamCreationFee {});
@@ -2723,7 +2723,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(101)),
-            toc_version: None,
+            tos_version: None,
         };
         let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(res, ContractError::InvalidExitFeePercent {});
@@ -2740,7 +2740,7 @@ mod test_module {
             fee_collector: Some("collector2".to_string()),
             accepted_in_denom: Some("new_denom".to_string()),
             exit_fee_percent: Some(Decimal256::percent(2)),
-            toc_version: None,
+            tos_version: None,
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2803,7 +2803,7 @@ mod test_module {
             fee_collector: Some("collector3".to_string()),
             accepted_in_denom: Some("new_denom2".to_string()),
             exit_fee_percent: Some(Decimal256::percent(5)),
-            toc_version: None,
+            tos_version: None,
         };
         execute(deps.as_mut(), env, info, msg).unwrap();
         //query config
@@ -2861,7 +2861,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -2909,7 +2909,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -2949,7 +2949,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
             assert_eq!(res, ContractError::StreamKillswitchActive {});
@@ -2963,7 +2963,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
             assert_eq!(res, ContractError::StreamKillswitchActive {});
@@ -3029,7 +3029,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3069,7 +3069,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3095,7 +3095,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
             assert_eq!(res, ContractError::StreamKillswitchActive {});
@@ -3122,7 +3122,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let res = execute(deps.as_mut(), env, info, msg).unwrap();
             assert_eq!(res.attributes[0].key, "action");
@@ -3177,7 +3177,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3217,7 +3217,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3306,7 +3306,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3346,7 +3346,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3501,7 +3501,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3541,7 +3541,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3591,7 +3591,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3671,7 +3671,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3731,7 +3731,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3743,7 +3743,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: None,
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3772,7 +3772,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: "in".to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3812,7 +3812,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -3928,7 +3928,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: in_denom.to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -3968,7 +3968,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
@@ -4042,7 +4042,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: in_denom.to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -4082,7 +4082,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
@@ -4093,7 +4093,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
@@ -4191,7 +4191,7 @@ mod test_module {
                 fee_collector: "collector".to_string(),
                 protocol_admin: "protocol_admin".to_string(),
                 accepted_in_denom: in_denom.to_string(),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
 
@@ -4231,7 +4231,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
@@ -4242,7 +4242,7 @@ mod test_module {
                 stream_id: 1,
                 operator_target: None,
                 operator: Some("operator".to_string()),
-                toc_version: "v1".to_string(),
+                tos_version: "v1".to_string(),
             };
             let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
             // Can not cancel stream before it ends

--- a/src/threshold.rs
+++ b/src/threshold.rs
@@ -110,7 +110,7 @@ mod tests {
     use super::*;
     use crate::state::Stream;
     use cosmwasm_std::testing::MockStorage;
-    use cosmwasm_std::{Addr, Decimal, Decimal256, Timestamp, Uint128};
+    use cosmwasm_std::{Addr, Decimal256, Timestamp, Uint128};
 
     #[test]
     fn test_thresholds_state() {


### PR DESCRIPTION
- Implement treasury cancel period:
    - This period begins automatically after stream creation.
    - Its duration matches the min_duration_until_stream_start_time.
    - During this period, only the TreasuryCancelStream{} operation is allowed.
    - No subscriptions or withdrawals can occur.